### PR TITLE
Bug fix save_df if_exists='replace'

### DIFF
--- a/docs/source/user_guide/sqlite/examples/load_table_localize_tz.py
+++ b/docs/source/user_guide/sqlite/examples/load_table_localize_tz.py
@@ -57,22 +57,44 @@ CustomerId;CustomerName;BirthDate;Residence;IsAdventurer
 6;Max Pure;2007-08-20;Port Sarim;1
 """)
 
-df = pd.read_csv(filepath_or_buffer=data, sep=';', index_col='CustomerId',
-                 parse_dates=['BirthDate'])  # Create a DataFrame
+dtypes = {
+    'CustomerId': 'int8',
+    'CustomerName': 'string',
+    'Residence': 'string',
+    'IsAdventurer': 'boolean'
+}
 
-with db.engine.connect() as conn:
+df = pd.read_csv(filepath_or_buffer=data, sep=';', index_col='CustomerId', dtype=dtypes)
+
+with db.engine.begin() as conn:
     db.execute(sql=create_table_customer, conn=conn)
     db.save_df(df=df, table='Customer', conn=conn, if_exists='replace')
 
-    df_naive = db.load_table(sql='Customer', conn=conn, index_col='CustomerId',
-                             parse_dates=['Birthdate'])
+    df_naive = db.load_table(
+        sql='Customer',
+        conn=conn,
+        index_col='CustomerId',
+        dtypes=dtypes,
+        parse_dates={'BirthDate': r'%Y-%m-%d'}
+    )
 
-    df_dt_aware = db.load_table(sql='Customer', conn=conn, index_col='CustomerId',
-                                parse_dates=['Birthdate'], localize_tz='UTC', target_tz='CET')
+    df_dt_aware = db.load_table(
+        sql='Customer',
+        conn=conn,
+        index_col='CustomerId',
+        dtypes=dtypes,
+        parse_dates={'BirthDate': r'%Y-%m-%d'},
+        localize_tz='UTC',
+        target_tz='CET'
+    )
 
 print(f'df:\n{df}\n')
+
 print(f'df_naive:\n{df_naive}\n')
-print(f'df_dt_aware:\n{df_dt_aware}')
+print(f'df_naive.dtypes:\n{df_naive.dtypes}\n')
+
+print(f'df_dt_aware:\n{df_dt_aware}\n')
+print(f'df_dt_aware.dtypes:\n{df_dt_aware.dtypes}')
 
 # ===============================================================
 # Clean up

--- a/tests/test_pandemy/test_SQLiteDb.py
+++ b/tests/test_pandemy/test_SQLiteDb.py
@@ -889,6 +889,26 @@ class TestSaveDfMethod:
         # Clean up - None
         # ===========================================================
 
+    @pytest.mark.raises
+    def test_save_column_with_invalid_data_type(self, sqlite_db_empty, df_customer):
+        r"""Save a DataFrame, containing a column with a data type not supported by SQLite, to an existing table.
+
+        SQLite does not support unsigned integers for the PRIMARY KEY column.
+        pandemy.SaveDataFrameError is expected to be raised.
+        """
+        # Setup
+        # ===========================================================
+        df_customer.index = df_customer.index.astype('uint8')
+
+        with sqlite_db_empty.engine.begin() as conn:
+            # Exercise & Verify
+            # ===========================================================
+            with pytest.raises(pandemy.SaveDataFrameError, match=r'[Uu]nsigned'):
+                sqlite_db_empty.save_df(df=df_customer, table='Customer', conn=conn)
+
+        # Clean up - None
+        # ===========================================================
+
     def test_index_False(self, sqlite_db_empty, df_customer):
         r"""Save a DataFrame to an existing empty table.
 


### PR DESCRIPTION
Updated the save_df if_exists option

    Fixed bug for if_exists='replace'. It now correctly deletes the data of the existing table
    before writing the DataFrame instead of dropping the table, recreating it, and finally writing the DataFrame.

    Added option 'drop-replace' to the if_exists parameter. This option does what the bug with 'replace' did before,
    which is also the way if_exists='replace' is implemented in the pandas.DataFrame.to_sql method.

Updated error handling of save_df method.

    The method now correctly triggers TableExistsError and SaveDataFrameError.
    If a ValueError is raised by the pandas.DataFrame.to_sql method, that is not related to
    "table exists and if_exists='fail'", the ValueError is translated into a SaveDataFrameError
    and not a TableExistsError as before.
