### PR TITLE
Update dependencies and configuration for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
   
 sphinx:
   builder: html
@@ -13,6 +13,7 @@ sphinx:
 formats:
   - pdf
   - htmlzip
+  - epub
 
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Pinned build requirements for Read the Docs
 
 docutils==0.16
-sphinx==4.4.0
-sphinx_rtd_theme==0.4.3
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1


### PR DESCRIPTION

## Dependencies
sphinx : v4.4.0 --> v5.3.0
sphinx_rtd_theme : v0.4.3 --> v1.1.1

## Read the Docs Configuration

Updated the OS to ubuntu-22.04 and Python version to 3.11.
Added epub as a format option for downloading the documentation.
